### PR TITLE
fix: corrige locators frágeis que falhavam no CI headless

### DIFF
--- a/resources/locators/checkout_locator.yaml
+++ b/resources/locators/checkout_locator.yaml
@@ -1,4 +1,4 @@
-HEADER_SECONDARY:  xpath://span[contains(text(),'Your Information')]
+HEADER_SECONDARY:  css:.header_secondary_container
 FIRST_NAME:        id:first-name
 LAST_NAME:         id:last-name
 POSTAL_CODE:       id:postal-code

--- a/resources/pages/carrinho.resource
+++ b/resources/pages/carrinho.resource
@@ -6,3 +6,4 @@ Variables        ../locators/carrinho_locator.yaml
 Vou para pagina de checkout
     Wait Until Element Is Visible    ${CART_LIST}
     Click Button                     ${BTN_CHECKOUT}
+    Wait Until Element Is Visible    id:first-name

--- a/resources/pages/checkout.resource
+++ b/resources/pages/checkout.resource
@@ -4,7 +4,7 @@ Variables        ../locators/checkout_locator.yaml
 
 *** Keywords ***
 Preencho as informacoes necessarias
-    Wait Until Element Is Visible    ${HEADER_SECONDARY}
+    Wait Until Element Is Visible    ${FIRST_NAME}
     ${fake_first_name}=     Fake First Name
     ${fake_last_name}=      Fake Last Name
     ${fake_postal_code}=    Fake Postal Code
@@ -13,7 +13,7 @@ Preencho as informacoes necessarias
     Input Text    ${POSTAL_CODE}    ${fake_postal_code}
 
 Tento continuar o checkout sem preencher os campos
-    Wait Until Element Is Visible    ${HEADER_SECONDARY}
+    Wait Until Element Is Visible    ${FIRST_NAME}
     Click Element                    ${BTN_CONTINUE}
 
 Erro de checkout e exibido
@@ -23,4 +23,4 @@ Erro de checkout e exibido
 
 Vou para pagina de finalizacao
     Run Keyword Until Success    Click Element    ${BTN_CONTINUE}
-    Wait Until Element Is Not Visible    ${HEADER_SECONDARY}
+    Wait Until Element Is Visible    id:finish

--- a/tests/TestCases.robot
+++ b/tests/TestCases.robot
@@ -94,8 +94,7 @@ Cenário 09: Checkout sem preencher o sobrenome
     And adicono um produto no carrinho
     And vou para pagina do carrinho
     And vou para pagina de checkout
-    When Wait Until Element Is Visible    ${HEADER_SECONDARY}
-    And Input Text    id:first-name    João
+    When Input Text    id:first-name    João
     And tento continuar o checkout sem preencher os campos
     Then erro de checkout e exibido    Error: Last Name is required
 
@@ -106,8 +105,7 @@ Cenário 10: Checkout sem preencher o CEP
     And adicono um produto no carrinho
     And vou para pagina do carrinho
     And vou para pagina de checkout
-    When Wait Until Element Is Visible    ${HEADER_SECONDARY}
-    And Input Text    id:first-name    João
+    When Input Text    id:first-name    João
     And Input Text    id:last-name     Silva
     And tento continuar o checkout sem preencher os campos
     Then erro de checkout e exibido    Error: Postal Code is required


### PR DESCRIPTION
- Troca HEADER_SECONDARY de xpath com texto para css:.header_secondary_container
- Adiciona wait por id:first-name após clicar em checkout no carrinho.resource
- checkout.resource espera o campo de input em vez do header para validar carregamento
- Vou para pagina de finalizacao espera id:finish em vez de not visible no header
- Remove waits redundantes com HEADER_SECONDARY nos cenários 09 e 10