### PR TITLE
fix: corrige clique no carrinho que falhava no CI headless

### DIFF
--- a/resources/locators/home_locator.yaml
+++ b/resources/locators/home_locator.yaml
@@ -1,2 +1,2 @@
 # O ID do botão é montado dinamicamente com base no PRODUCT_ID definido no config.yaml
-GO_TO_CART: id:shopping_cart_container
+GO_TO_CART: css:.shopping_cart_link

--- a/resources/pages/home.resource
+++ b/resources/pages/home.resource
@@ -10,5 +10,6 @@ Adicono um produto no carrinho
     Click Button                     ${add_to_cart_btn}
 
 Vou para pagina do carrinho
-    Run Keyword Until Success    Click Element    ${GO_TO_CART}
-    Wait Until Page Contains Element    css:.cart_list
+    Wait Until Element Is Visible    ${GO_TO_CART}
+    Click Element                    ${GO_TO_CART}
+    Wait Until Location Contains     cart.html


### PR DESCRIPTION
- Troca locator do carrinho de id:shopping_cart_container para css:.shopping_cart_link
- Usa Wait Until Location Contains cart.html para confirmar navegação
- Remove retry desnecessário e usa wait explícito por visibilidade antes do clique